### PR TITLE
:hammer: slight tweaks to tailscale commands

### DIFF
--- a/owid/tailscale.nu
+++ b/owid/tailscale.nu
@@ -3,22 +3,27 @@ export def "status" [] {
 }
 
 export def "users" [] {
-  tailscale status 
-  | get User 
-  | transpose id record 
-  | get record 
+  status
+  | get User
+  | transpose id record
+  | get record
   | select ID LoginName DisplayName
   | rename userid login name
 }
 
 export def "hosts" [] {
-  tailscale status 
-  | get Peer 
-  | transpose peer record 
-  | get record 
-  | select HostName DNSName Online UserID 
-  | rename host dns online userid 
-  | join (tailscale users) userid 
+  status
+  | get Peer
+  | transpose peer record
+  | get record
+  | select HostName DNSName Online UserID
+  | rename host dns online userid
+  | join (users) userid
   | reject name
   | update dns {|it| ($it).dns | str replace -r '\.$' '' }
+}
+
+# Commands for seeing tailscale users and hosts
+export def main [] {
+
 }


### PR DESCRIPTION
This PR modifies the tailscale commands slightly:

It adds an exported main function - this is mainly to improve autocomplete behaviour. Without it, when you have typed `owid tailscale` you get file autocomplete, with this main function you get the 3 possible subcommand (plus the empty main as just owid tailscale)

The functions didn't quite work for me with the new naming - did you have the old definitions still in scope? Within a file based module, the filename prefix should not be used.