### PR TITLE
Add "owid spaces" command as an alias for "aws s3 --profile..."

### DIFF
--- a/owid/mod.nu
+++ b/owid/mod.nu
@@ -22,3 +22,4 @@ export module mysql.nu
 export module r2.nu
 export module site.nu
 export module tailscale.nu
+export module spaces.nu

--- a/owid/spaces.nu
+++ b/owid/spaces.nu
@@ -1,0 +1,17 @@
+#
+#  spaces.nu
+#
+#  Use "owid spaces ..." instead of "aws s3 ..." to interact with DigitalOcean spaces
+#  using the AWS CLI. It encourages you to have no [default] credentials in ~/.aws, meaning
+#  you can't mess up and accidentally use the wrong credentials.
+#  
+
+# Set up the owid-spaces profile for S3
+export def configure [] {
+    aws configure --profile=owid-spaces
+}
+
+# Interact with S3 using the owid-spaces profile
+export def main [...args] {
+    aws --profile=owid-spaces s3 --endpoint-url=https://nyc3.digitaloceanspaces.com ...$args
+}


### PR DESCRIPTION
Since we use multiple object stores, we want to avoid putting credentials in the `[default]` block of `~/.aws/config`. This is before even considering other non-OWID projects.

This `owid spaces` helper is just an alias for the `aws s3` command that encourages good separation of credentials.
